### PR TITLE
web app URL - change to use MSFT hostnames

### DIFF
--- a/articles/known-issues.md
+++ b/articles/known-issues.md
@@ -81,8 +81,8 @@ When using Connected Spaces, make sure you're using the web app in the geographi
 
 | Your AAD account region | Connected Spaces web app URL |
 | --- | --- |
-| United States | https://cspperegionalwestus.azurewebsites.net/ |
-| United Kingdom | https://cspperegionaluksouth.azurewebsites.net/ |
+| United States | https://us.ppe.connectedspaces.dynamics.com/ |
+| United Kingdom | https://uk.ppe.connectedspaces.dynamics.com/ |
 
 Doing this will ensure that Connected Spaces will be able to process your customer data within your company's geographic region.
 


### PR DESCRIPTION
We've deployed changes to our service, to run under our own MSFT hostnames now (under connectedspaces.dynamics.com)